### PR TITLE
drupal:drush execute the same command on all servers.

### DIFF
--- a/lib/capistrano/tasks/drupal_deploy.rake
+++ b/lib/capistrano/tasks/drupal_deploy.rake
@@ -41,9 +41,10 @@ namespace :drupal do
   desc 'Run any drush command'
   task :drush do
     ask(:drush_command, "Drush command you want to run (eg. 'cache-clear css-js'). Type 'help' to have a list of avaible drush commands.")
+    command = fetch(:drush_command)
     on roles(:app) do
       within release_path.join(fetch(:app_path)) do
-        execute :drush, fetch(:drush_command)
+        execute :drush, command
       end
     end
   end


### PR DESCRIPTION
Due the nature of capistrano's `ask` method and the parallelism of
the `roles` method the value of `fetch(:drupal_command)` is undefined
for every run of the `roles` loop

This commit forces the evaluation of `:drupal_command` before enter
the `roles` loop, efectively launching the same command on each host in
parallel

Whitout this commit:

```
22:44 $ cap production drupal:drush
Using airbrussh format.
Verbose output is being written to log/capistrano.log.
Please enter drush_command (Drush command you want to run (eg. 'cache-clear css-js'). Type 'help' to have a list of avaible drush commands.): Please enter drush_command (Drush command you want to run (eg. 'cache-clear css-js'). Type 'help' to have a list of avaible drush commands.): cc all
00:00 drupal:drush
      01 /var/www/test/shared/vendor/bin/drush cc all 
    ✔ 01 ubuntu@server1 5.238s
help
      02 /var/www/test/shared/vendor/bin/drush help
    ✔ 02 ubuntu@server2 0.657s
```

As you see the "promp" question for `ask` appears twice, then capistrano executes in one server and then appears to be hang. But it is waiting for the input of "another" `ask`

with this commit

```
22:47 $ cap production drupal:drush
Using airbrussh format.
Verbose output is being written to log/capistrano.log.
Please enter drush_command (Drush command you want to run (eg. 'cache-clear css-js'). Type 'help' to have a list of avaible drush commands.): cc all 
00:00 drupal:drush
      01 /var/www/test/shared/vendor/bin/drush cc all 
    ✔ 01 ubuntu@server1 5.043s
    ✔ 01 ubuntu@server2 5.305s
```

Assignation forces preevaluation of the ask before launch commands.
